### PR TITLE
Allow building with Zig 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
       - run: zig build test --summary all
       - run: (cd example && zig build run)
 
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
       - run: zig fmt --check .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
       - run: zig build docs
       - uses: actions/upload-pages-artifact@v3
         id: deployment

--- a/build.zig
+++ b/build.zig
@@ -15,11 +15,7 @@ pub fn build(b: *std.Build) void {
     });
     axe.addImport("zeit", zeit);
 
-    const tests = b.addTest(.{
-        .root_source_file = b.path("src/axe.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
+    const tests = b.addTest(.{ .root_module = axe });
     tests.root_module.addImport("zeit", zeit);
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run tests");
@@ -28,9 +24,7 @@ pub fn build(b: *std.Build) void {
     const docs_step = b.step("docs", "Generate documentation");
     const docs_obj = b.addObject(.{
         .name = "axe",
-        .root_source_file = b.path("src/axe.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = axe,
     });
     const docs = docs_obj.getEmittedDocs();
     docs_step.dependOn(&b.addInstallDirectory(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .zeit = .{
-            .url = "https://github.com/rockorager/zeit/archive/refs/tags/v0.6.0.tar.gz",
-            .hash = "zeit-0.0.0-5I6bk_pZAgB03N1p1GmVOZ--gOFwwQSRKj1UXb5tnaKS",
+            .url = "git+https://github.com/rockorager/zeit?ref=zig-0.15#06ec40445cc477fea5a8369f1ba3881e2a3c00eb",
+            .hash = "zeit-0.6.0-5I6bkyJ8AgAS1_0NDvfxmFsBDTOxkZXtLUHrmPjcmt-K",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .axe,
-    .version = "0.6.1",
+    .version = "0.7.0",
     .fingerprint = 0x6c6a1e2ce5546233,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0-dev.1438+242102f9d",
     .dependencies = .{
         .zeit = .{
-            .url = "git+https://github.com/rockorager/zeit?ref=zig-0.15#06ec40445cc477fea5a8369f1ba3881e2a3c00eb",
-            .hash = "zeit-0.6.0-5I6bkyJ8AgAS1_0NDvfxmFsBDTOxkZXtLUHrmPjcmt-K",
+            .url = "git+https://github.com/rockorager/zeit?ref=zig-0.15#ed2ca60db118414bda2b12df2039e33bad3b0b88",
+            .hash = "zeit-0.6.0-5I6bk0J9AgCVa0nnyL0lNY9Xa9F68hHq-ZarhuXNV-Jb",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .axe,
     .version = "0.7.0",
     .fingerprint = 0x6c6a1e2ce5546233,
-    .minimum_zig_version = "0.15.0-dev.1438+242102f9d",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{
         .zeit = .{
             .url = "git+https://github.com/rockorager/zeit?ref=zig-0.15#ed2ca60db118414bda2b12df2039e33bad3b0b88",

--- a/example/build.zig
+++ b/example/build.zig
@@ -7,11 +7,15 @@ pub fn build(b: *std.Build) void {
     const axe = b.dependency("axe", .{}).module("axe");
     const exe = b.addExecutable(.{
         .name = "example",
-        .root_source_file = b.path("example.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("example.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "axe", .module = axe },
+            },
+        }),
     });
-    exe.root_module.addImport("axe", axe);
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/example/build.zig.zon
+++ b/example/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .example,
     .version = "0.0.0",
-    .minimum_zig_version = "0.15.0-dev.1438+242102f9d",
+    .minimum_zig_version = "0.15.1",
     .fingerprint = 0x6eec9b9f528bcd1e,
     .dependencies = .{
         .axe = .{

--- a/example/build.zig.zon
+++ b/example/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = .example,
     .version = "0.0.0",
+    .minimum_zig_version = "0.15.0-dev.1438+242102f9d",
     .fingerprint = 0x6eec9b9f528bcd1e,
     .dependencies = .{
         .axe = .{

--- a/example/example.zig
+++ b/example/example.zig
@@ -17,29 +17,34 @@ pub fn main() !void {
     const allocator = gpa.allocator();
     var env = try std.process.getEnvMap(allocator);
     defer env.deinit();
+    var buffer: [128]u8 = undefined;
 
-    // stdout instead of stderr:
-    // note that unless .color is .always no color will be output to stdout
-    //   since only stderr has automatic color detection
-    const stdout_log = axe.Axe(.{
-        .format = "[%l]%s: %m\n", // the log format string, default is "%l%s:%L %m\n"
-        .scope_format = " ~ %", // % is a placeholder for scope, default is "(%)"
-        .loc_format = "", // unused here, default is " %f:%l:"
-        .time_format = .disabled, // disabled by default
-        .color = .never, // .auto by default
-        .styles = .none, // colored by default, useless to change here since color is never
-        .level_text = .{ // same as zig by default
-            .err = "ErrOr",
-            .debug = "DeBuG",
-        },
-        .quiet = true, // disable stderr logging, default is false
-        .buffering = true, // default is true
-        .mutex = .none, // none by default
-    });
-    try stdout_log.init(allocator, &.{fileWriter(std.io.getStdOut())}, &env);
-    defer stdout_log.deinit(allocator);
-    stdout_log.debug("Hello, stdout with no colors", .{});
-    stdout_log.scoped(.main).err("scoped :)", .{});
+    {
+        // stdout instead of stderr:
+        // note that unless .color is .always no color will be output to stdout
+        //   since only stderr has automatic color detection
+        const stdout_log = axe.Axe(.{
+            .format = "[%l]%s: %m\n", // the log format string, default is "%l%s:%L %m\n"
+            .scope_format = " ~ %", // % is a placeholder for scope, default is "(%)"
+            .loc_format = "", // unused here, default is " %f:%l:"
+            .time_format = .disabled, // disabled by default
+            .color = .never, // .auto by default
+            .styles = .none, // colored by default, useless to change here since color is never
+            .level_text = .{ // same as zig by default
+                .err = "ErrOr",
+                .debug = "DeBuG",
+            },
+            .quiet = true, // disable stderr logging, default is false
+            .flush_each_log = true, // default is true
+            .mutex = .none, // none by default
+        });
+        var writer = std.fs.File.stdout().writer(&buffer);
+        defer writer.interface.flush() catch unreachable;
+        try stdout_log.init(allocator, &.{&writer.interface}, &env);
+        defer stdout_log.deinit(allocator);
+        stdout_log.debug("Hello, stdout with no colors", .{});
+        stdout_log.scoped(.main).err("scoped :)", .{});
+    }
 
     // std.log:
     // init is technically optional but highly recommened, it's used to check
@@ -50,92 +55,68 @@ pub fn main() !void {
     std.log.info("std.log.info with axe.Axe(.{{}})", .{});
     std.log.scoped(.main).warn("this is scoped", .{});
 
-    // custom writers:
-    var f = try std.fs.cwd().createFile("log.txt", .{});
-    defer f.close();
-    const log = axe.Axe(.{
-        .format = "%t %l%s%L %m\n",
-        .scope_format = "@%",
-        .time_format = .{ .gofmt = .date_time }, // .date_time is a preset but custom format is also possible
-        .styles = .{
-            .err = &.{ .{ .bg_hex = "ff0000" }, .bold, .underline },
-            .warn = &.{ .{ .rgb = .{ .r = 255, .g = 255, .b = 0 } }, .strikethrough },
-            .info = &.{ .green, .italic },
-        },
-        .level_text = .{
-            .err = "ERROR",
-            .warn = "WARN",
-            .info = "INFO",
-            .debug = "DEBUG",
-        },
-        .mutex = .default, // default to std.Thread.Mutex
-    });
-    // Note that we're using .any() to convert std.io.GenericWriter to std.io.AnyWriter.
-    // It is highly recommended to instead implement std.io.AnyWriter because .any()
-    //   uses a pointer to the GenericWriter context which could create a dangling pointer.
-    // See `fileWriter` for an example of how to implement std.io.AnyWriter for a file.
-    // See `arrayListWriter` in axe.zig for another example with ArrayList(u8).
-    try log.init(allocator, &.{f.writer().any()}, &env);
-    defer log.deinit(allocator);
+    {
+        // custom writers:
+        var f = try std.fs.cwd().createFile("log.txt", .{});
+        defer f.close();
+        const log = axe.Axe(.{
+            .format = "%t %l%s%L %m\n",
+            .scope_format = "@%",
+            .time_format = .{ .gofmt = .date_time }, // .date_time is a preset but custom format is also possible
+            .styles = .{
+                .err = &.{ .{ .bg_hex = "ff0000" }, .bold, .underline },
+                .warn = &.{ .{ .rgb = .{ .r = 255, .g = 255, .b = 0 } }, .strikethrough },
+                .info = &.{ .green, .italic },
+            },
+            .level_text = .{
+                .err = "ERROR",
+                .warn = "WARN",
+                .info = "INFO",
+                .debug = "DEBUG",
+            },
+            .mutex = .default, // default to std.Thread.Mutex
+        });
+        // Note that we're using .any() to convert std.io.GenericWriter to std.io.AnyWriter.
+        // It is highly recommended to instead implement std.io.AnyWriter because .any()
+        //   uses a pointer to the GenericWriter context which could create a dangling pointer.
+        // See `fileWriter` for an example of how to implement std.io.AnyWriter for a file.
+        // See `arrayListWriter` in axe.zig for another example with ArrayList(u8).
 
-    log.debug("Hello! This will have no color if NO_COLOR is defined or if piped", .{});
-    log.scoped(.main).infoAt(@src(), "the time can be formatted like strftime or time.go", .{});
-    log.errAt(@src(), "this is thread safe!", .{});
-    log.warn("this is output to stderr and log.txt (without colors)", .{});
+        var writer = f.writer(&buffer);
+        defer writer.interface.flush() catch unreachable;
+        try log.init(allocator, &.{&writer.interface}, &env);
+        defer log.deinit(allocator);
 
-    // json log:
-    var json_file = try std.fs.cwd().createFile("log.json", .{});
-    defer json_file.close();
-    const json_log = axe.Axe(.{
-        .format =
-        \\{"level":"%l",%s"time":"%t","data":%m}
-        \\
-        ,
-        .scope_format =
-        \\"scope":"%",
-        ,
-        .time_format = .{ .gofmt = .rfc3339 },
-        .color = .never,
-    });
-    try json_log.init(allocator, &.{fileWriter(json_file)}, &env);
-    defer json_log.deinit(allocator);
-
-    json_log.debug("\"json log\"", .{});
-    json_log.scoped(.main).info("\"json scoped\"", .{});
-    // it's easy to have struct instead of a string as data
-    const data = .{ .a = 42, .b = 3.14 };
-    json_log.info("{}", .{std.json.fmt(data, .{})});
-}
-
-fn fileWriter(file: std.fs.File) std.io.AnyWriter {
-    if (builtin.os.tag == .windows) {
-        return fileWriterWindows(file);
-    } else {
-        return fileWriterPosix(file);
+        log.debug("Hello! This will have no color if NO_COLOR is defined or if piped", .{});
+        log.scoped(.main).infoAt(@src(), "the time can be formatted like strftime or time.go", .{});
+        log.errAt(@src(), "this is thread safe!", .{});
+        log.warn("this is output to stderr and log.txt (without colors)", .{});
     }
-}
 
-fn fileWriterPosix(file: std.fs.File) std.io.AnyWriter {
-    // It's fine to store the handle as the pointer here because it's small enough to fit in.
-    return .{
-        .context = @ptrFromInt(@as(usize, @intCast(file.handle))),
-        .writeFn = struct {
-            fn typeErasedWrite(context: *const anyopaque, bytes: []const u8) !usize {
-                const self: std.fs.File = .{ .handle = @intCast(@intFromPtr(context)) };
-                return self.write(bytes);
-            }
-        }.typeErasedWrite,
-    };
-}
+    {
+        // json log:
+        var json_file = try std.fs.cwd().createFile("log.json", .{});
+        defer json_file.close();
+        const json_log = axe.Axe(.{
+            .format =
+            \\{"level":"%l",%s"time":"%t","data":%m}
+            \\
+            ,
+            .scope_format =
+            \\"scope":"%",
+            ,
+            .time_format = .{ .gofmt = .rfc3339 },
+            .color = .never,
+        });
+        var writer = json_file.writer(&buffer);
+        defer writer.interface.flush() catch unreachable;
+        try json_log.init(allocator, &.{&writer.interface}, &env);
+        defer json_log.deinit(allocator);
 
-fn fileWriterWindows(file: std.fs.File) std.io.AnyWriter {
-    return .{
-        .context = file.handle,
-        .writeFn = struct {
-            fn typeErasedWrite(context: *const anyopaque, bytes: []const u8) !usize {
-                const self: std.fs.File = .{ .handle = @constCast(context) };
-                return self.write(bytes);
-            }
-        }.typeErasedWrite,
-    };
+        json_log.debug("\"json log\"", .{});
+        json_log.scoped(.main).info("\"json scoped\"", .{});
+        // it's easy to have struct instead of a string as data
+        const data = .{ .a = 42, .b = 3.14 };
+        json_log.info("{f}", .{std.json.fmt(data, .{})});
+    }
 }

--- a/example/example.zig
+++ b/example/example.zig
@@ -35,7 +35,6 @@ pub fn main() !void {
                 .debug = "DeBuG",
             },
             .quiet = true, // disable stderr logging, default is false
-            .flush_each_log = true, // default is true
             .mutex = .none, // none by default
         });
         var writer = std.fs.File.stdout().writer(&buffer);

--- a/example/example.zig
+++ b/example/example.zig
@@ -12,7 +12,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     var env = try std.process.getEnvMap(allocator);

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755605615,
-        "narHash": "sha256-J0Cxren2QLeI0ZvRZw4XGcMm4q3uPIZHM+eJnaZfXX8=",
+        "lastModified": 1755864794,
+        "narHash": "sha256-hgnov6RLA+DD4Uocs/vCbiH3/3sKvqiJOKHpdhGyVAI=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "714fae26049a263ff2e4641ce7c973f371f4b005",
+        "rev": "5cd601f8760d2383210b7b8c8a45fc79388f3ddf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     zig,
     ...
   }: let
-    zig-version = "0.14.1";
+    zig-version = "0.15.1";
     overlays = [zig.overlays.default];
     systems = builtins.attrNames zig.packages;
   in

--- a/src/axe.zig
+++ b/src/axe.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const zeit = @import("zeit");
 const windows = std.os.windows;
-const tty = std.io.tty;
+const tty = std.Io.tty;
 
 pub const Config = struct {
     /// The format to use for the log messages.
@@ -84,7 +84,6 @@ pub fn Axe(comptime config: Config) type {
         var writers: []*std.Io.Writer = &.{};
         // zig/llvm can't handle this without explicit type
         var stderr_tty_config: if (config.quiet) void else tty.Config = if (config.quiet) {} else .no_color;
-
         var timezone = if (config.time_format != .disabled) zeit.utc else {};
         var mutex = switch (config.mutex) {
             .none, .function => {},
@@ -283,8 +282,8 @@ pub fn Axe(comptime config: Config) type {
                 if (!config.quiet) {
                     var buffer: [256]u8 = undefined;
                     var stderr = std.fs.File.stderr().writer(&buffer);
-                    defer stderr.interface.flush() catch {};
                     print(src, &stderr.interface, stderr_tty_config, time, level, scope, format, args);
+                    stderr.interface.flush() catch {};
                 }
             }
         }


### PR DESCRIPTION
- [x] In `build.zig`, specify `root_module`
- [x] Bump dependency for 0.15
- [x] Use the new `{f}` formatter syntax
- [x] Adapt IOs post writergate 